### PR TITLE
Command couchbase-cli not found

### DIFF
--- a/manifests/bucket.pp
+++ b/manifests/bucket.pp
@@ -52,7 +52,7 @@ define couchbase::bucket (
   Class['couchbase::service'] -> Couchbase::Bucket[$title]
 
   exec {"bucket-create-${title}":
-    path      => ['/opt/couchbase/bin/', '/usr/bin/'],
+    path      => ['/opt/couchbase/bin/', '/usr/bin/', '/bin', '/sbin', '/usr/sbin'],
     command   => "couchbase-cli bucket-create -c localhost -u ${user} -p '${password}' --bucket=${title} --bucket-type=${type} --bucket-ramsize=${size} --bucket-port=${port} --bucket-replica=${replica}",
     require   => Class['couchbase::config'],
     returns   => [0, 2],


### PR DESCRIPTION
More paths need to be added in order to not throw 'command not found' when referring to the couchbase-cli executable. (tested on Centos 6.4)
