### PR TITLE
Changed package path for community to correct path

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -23,7 +23,7 @@ class couchbase::install (
 
   $pkgname = $edition ? {
         'enterprise'  => "couchbase-server-enterprise_${version}_x86_64.${couchbase::params::pkgtype}",
-        'community'   => "couchbase-server-community_x86_64_${version}.${couchbase::params::pkgtype}",
+        'community'   => "couchbase-server-community_${version}_x86_64.${couchbase::params::pkgtype}",
         default       => "couchbase-server-enterprise_${version}_x86_64.${couchbase::params::pkgtype}",
     }
 


### PR DESCRIPTION
Looks like the path for community version may have changed. Verified for .deb and .rpm
