### PR TITLE
Updated links to work with debian, redhat, centos, and ubuntu.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -22,10 +22,21 @@ class couchbase::install (
 ) {
   include couchbase::params
 
+  case $::operatingsystem {
+    'RedHat' , 'CentOS': {
+      $version_complete = "${version}-centos${::operatingsystemrelease}.x86_64"
+    }
+    'debian': {
+      $version_complete = "${version}-debian${::operatingsystemrelease}_amd64"
+    }
+    'ubuntu': {
+      $version_complete = "${version}-ubuntu${::operatingsystemrelease}_amd64"
+    }      
+  }
   $pkgname = $edition ? {
-        'enterprise'  => "couchbase-server-enterprise_${version}_x86_64.${couchbase::params::pkgtype}",
-        'community'   => "couchbase-server-community_${version}_x86_64.${couchbase::params::pkgtype}",
-        default       => "couchbase-server-enterprise_${version}_x86_64.${couchbase::params::pkgtype}",
+        'enterprise'  => "couchbase-server-enterprise_${version_complete}.${couchbase::params::pkgtype}",
+        'community'   => "couchbase-server-community_${version_complete}.${couchbase::params::pkgtype}",
+        default       => "couchbase-server-enterprise_${version_complete}.${couchbase::params::pkgtype}",
     }
 
   $pkgsource = "http://packages.couchbase.com/releases/${version}/${pkgname}"


### PR DESCRIPTION
Couchbase must have changed the URL naming convention for their download links.  I have updated to work with the latest version of URLs for debian, redhat, centos, and ubuntu.
