### PR TITLE
Added option for custom download url base

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,17 +44,18 @@
 
 class couchbase
 (
-  $size           = 1024,
-  $user           = 'couchbase',
-  $password       = 'password',
-  $version        = $::couchbase::params::version,
-  $edition        = $::couchbase::params::edition,
-  $nodename       = $::fqdn,
-  $server_group   = 'default',
-  $install_method = 'curl',
-  $ensure         = 'present',
-  $autofailover   = $::couchbase::params::autofailover,
-  $data_dir       = $::couchbase::params::data_dir,
+  $size              = 1024,
+  $user              = 'couchbase',
+  $password          = 'password',
+  $version           = $::couchbase::params::version,
+  $edition           = $::couchbase::params::edition,
+  $nodename          = $::fqdn,
+  $server_group      = 'default',
+  $install_method    = 'curl',
+  $ensure            = 'present',
+  $autofailover      = $::couchbase::params::autofailover,
+  $data_dir          = $::couchbase::params::data_dir,
+  $download_url_base = $::couchbase::params::download_url_base,
 ) inherits ::couchbase::params {
   
   # TODO: Add parameter data validation
@@ -125,8 +126,9 @@ class couchbase
     Anchor['couchbase::begin'] ->
 
     class {'couchbase::install':
-      version => $version,
-      edition => $edition,
+      version           => $version,
+      edition           => $edition,
+      download_url_base => $download_url_base,
     }
 
     ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,9 +16,10 @@
 # Copyright 2013 Justice London, unless otherwise noted.
 #
 class couchbase::install (
-  $version = $couchbase::version,
-  $edition = $couchbase::edition,
-  $method  = $couchbase::install_method,
+  $version           = $couchbase::version,
+  $edition           = $couchbase::edition,
+  $method            = $couchbase::install_method,
+  $download_url_base = $couchbase::download_url_base
 ) {
   include couchbase::params
 
@@ -31,7 +32,7 @@ class couchbase::install (
         default      => $pkgname_community,
     }
 
-  $pkgsource = "http://packages.couchbase.com/releases/${version}/${pkgname}"
+  $pkgsource = "${download_url_base}/${version}/${pkgname}"
 
   case $method {
     'curl': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class couchbase::params {
   $version             = '3.0.1'
   $edition             = 'community'
   $client_package      = 'libcouchbase2-libevent'
+  $download_url_base   = 'http://packages.couchbase.com/releases/'
   $ensure              = 'present'
   $autofailover        = true
   $data_dir            = '/opt/couchbase/var/lib/couchbase/data'


### PR DESCRIPTION
This added the option to specify the download base for the couchbase package.

I've avoid changing things too much so you'll need to add a `/${version}/` folder to the location but this adds some flexibility.

Let me know if you want anything changing