### PR TITLE
add parameter index_dir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,7 @@ class couchbase
   $ensure            = 'present',
   $autofailover      = $::couchbase::params::autofailover,
   $data_dir          = $::couchbase::params::data_dir,
+  $index_dir        = undef,
   $download_url_base = $::couchbase::params::download_url_base,
 ) inherits ::couchbase::params {
   

--- a/templates/couchbasenode_init.erb
+++ b/templates/couchbasenode_init.erb
@@ -2,4 +2,6 @@
 
 /opt/couchbase/bin/couchbase-cli node-init -c localhost \
 --node-init-data-path=<%= @data_dir %> \
+<% if @index_dir -%>--node-init-index-path=<%= @index_dir %> \ 
+<% end -%>
 -u <%= @user %> -p '<%= @password %>' && touch /opt/couchbase/var/.node_init


### PR DESCRIPTION
add optional parameter index_dir, if set it adds
--node-init-index-path=<%= @index_dir %> to node init command in
templates/couchbasenode_init.erb