### PR TITLE
when looking for buckets use an exact match

### DIFF
--- a/manifests/bucket.pp
+++ b/manifests/bucket.pp
@@ -73,7 +73,7 @@ define couchbase::bucket (
     exec {"bucket-create-${bucketname}":
       path      => ['/opt/couchbase/bin/', '/usr/bin/', '/bin', '/sbin', '/usr/sbin'],
       command   => "couchbase-cli bucket-create -c 127.0.0.1 ${create_command}",
-      unless    => "couchbase-cli bucket-list -c 127.0.0.1 -u ${user} -p '${password}' | grep ${bucketname}",
+      unless    => "couchbase-cli bucket-list -c 127.0.0.1 -u ${user} -p '${password}' | grep -x ${bucketname}",
       require   => Class['couchbase::config'],
       returns   => [0, 2],
       logoutput => true


### PR DESCRIPTION
When couchbase::buckets checks if a defined bucket has to be created make
sure that the check condition (current implemetation uses grep(1)) uses an exact
match and not allow substring match to trick it.