### PR TITLE
params: remove trailing slash in $download_url_base

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,7 @@ class couchbase::params {
   $version             = '3.0.1'
   $edition             = 'community'
   $client_package      = 'libcouchbase2-libevent'
-  $download_url_base   = 'http://packages.couchbase.com/releases/'
+  $download_url_base   = 'http://packages.couchbase.com/releases'
   $ensure              = 'present'
   $autofailover        = true
   $data_dir            = '/opt/couchbase/var/lib/couchbase/data'


### PR DESCRIPTION
A spurious trailing slash in $download_url_base resulted in a double-slash
in the URL passed to curl.
The endpoint server doesn't like such URL and replies with a `AccessDenied`
error code, making installation fail. Removing the trailing slash in the
base URL fixes it.

Signed-off-by: Luca Bruno <lucab@debian.org>