### PR TITLE
Fixed issue with curl url

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,7 @@ class couchbase::params {
   $version             = '3.0.1'
   $edition             = 'community'
   $client_package      = 'libcouchbase2-libevent'
-  $download_url_base   = 'http://packages.couchbase.com/releases/'
+  $download_url_base   = 'http://packages.couchbase.com/releases'
   $ensure              = 'present'
   $autofailover        = true
   $data_dir            = '/opt/couchbase/var/lib/couchbase/data'


### PR DESCRIPTION
The url had a double // which gave me following error:

```
==> 1404: Notice: /Stage[main]/Couchbase::Install/Notify[check the community: couchbase-server-community_3.0.1-ubuntu12.04_amd64.deb]/message: defined 'message' as 'check the community: couchbase-server-community_3.0.1-ubuntu12.04_amd64.deb'
==> 1404: Notice: check the pkgsource: http://packages.couchbase.com/releases//3.0.1/couchbase-server-community_3.0.1-ubuntu12.04_amd64.deb
==> 1404: Notice: /Stage[main]/Couchbase::Install/Notify[check the pkgsource: http://packages.couchbase.com/releases//3.0.1/couchbase-server-community_3.0.1-ubuntu12.04_amd64.deb]/message: defined 'message' as 'check the pkgsource: http://packages.couchbase.com/releases//3.0.1/couchbase-server-community_3.0.1-ubuntu12.04_amd64.deb'
==> 1404: Error: Execution of '/usr/bin/dpkg --force-confold -i /opt/couchbase-server-community_3.0.1-ubuntu12.04_amd64.deb' returned 1: dpkg-deb: error: `/opt/couchbase-server-community_3.0.1-ubuntu12.04_amd64.deb' is not a debian format archive
==> 1404: dpkg: error processing archive /opt/couchbase-server-community_3.0.1-ubuntu12.04_amd64.deb (--install):
==> 1404:  subprocess dpkg-deb --control returned error exit status 2
```
