### PR TITLE
Allow client package override

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,4 +1,4 @@
-# == Class: couchbase::client
+# == Type: couchbase::client
 #
 # Installs the libcouchbase client library, and the SDK for the desired programming language.
 # If the language is not specified, it will only install libcouchbase.
@@ -8,24 +8,41 @@
 # Alex Farcas <alex.farcas@gmail.com>
 #
 define couchbase::client(
-  $package_ensure = present
+  $package_ensure = present,
+  $client_package = $::couchbase::params::client_package,
+  $development_package = $::couchbase::params::development_package
 ) {
-  include ::couchbase::params
   include ::couchbase::repository
-
-  package { $::couchbase::params::development_package:
-    ensure  => $package_ensure,
-    require => Class['couchbase::repository'],
+  
+  if ! defined(Package[$development_package]) {
+    package { $development_package:
+      ensure  => $package_ensure,
+      require => Class['couchbase::repository'],
+    }
   }
   
-  package { $::couchbase::params::client_package:
-    ensure  => $package_ensure,
-    require => Package[$::couchbase::params::development_package],
+  if ! defined(Package[$client_package]) {
+    package { $client_package:
+      ensure  => $package_ensure,
+      require => Package[$development_package],
+    }
   }
   
   case $title {
-    ruby: { include ::couchbase::client::ruby }
-    python: { include ::couchbase::client::python }
+    ruby: { 
+      class { '::couchbase::client::ruby':
+        package_ensure      => $package_ensure,
+        client_package      => $client_package,
+        development_package => $development_package,
+      }      
+    }
+    python: { 
+      class { '::couchbase::client::python':
+        package_ensure      => $package_ensure,
+        client_package      => $client_package,
+        development_package => $development_package,
+      }      
+    }
     default: { }
   }
 }

--- a/manifests/client/python.pp
+++ b/manifests/client/python.pp
@@ -8,17 +8,17 @@
 # Alex Farcas <alex.farcas@gmail.com>
 #
 class couchbase::client::python(
-  $package_ensure = present
-) {
-  include couchbase::params
-
+  $package_ensure = present,
+  $client_package = $::couchbase::params::client_package,
+  $development_package = $::couchbase::params::development_package
+) inherits ::couchbase::params {
   package { 'couchbase_python':
     ensure   => $package_ensure,
     name     => 'couchbase',
     provider => 'pip',
     require  => [
-      Package[$::couchbase::params::client_package],
-      Package[$::couchbase::params::development_package]
+      Package[$client_package],
+      Package[$development_package]
     ]
   }
 }

--- a/manifests/client/ruby.pp
+++ b/manifests/client/ruby.pp
@@ -8,17 +8,17 @@
 # Alex Farcas <alex.farcas@gmail.com>
 #
 class couchbase::client::ruby(
-  $package_ensure = present
-) {
-  include couchbase::params
-
+  $package_ensure = present,
+  $client_package = $::couchbase::params::client_package,
+  $development_package = $::couchbase::params::development_package
+) inherits ::couchbase::params {
   package { 'couchbase_ruby':
     ensure   => $package_ensure,
     name     => 'couchbase',
     provider => 'gem',
     require  => [
-      Package[$::couchbase::params::client_package],
-      Package[$::couchbase::params::development_package]
+      Package[$client_package],
+      Package[$development_package]
     ]
   }
 }


### PR DESCRIPTION
In a recent VM build (centos 6.6) i noticed that the memcached and couchbase client libraries conflict. They are both using libevent, but while memcached is using the standard centos repo libevent, couchbase is using libcouchbase2-libevent from the couchbase repo.

It turns out that couchbase can also use libcouchbase2-libev and this solves the conflict with memcached. But to do that one needs to be able to override the default client_package, hence this PR.