### PR TITLE
Add quotes around password in couchbase-cluster-init.sh

### DIFF
--- a/templates/couchbase-cluster-init.sh.erb
+++ b/templates/couchbase-cluster-init.sh.erb
@@ -2,7 +2,7 @@
 --cluster-init-username=<%= @user %> --cluster-init-password='<%= @password %>' \
 --cluster-init-port=8091 \
 --cluster-init-ramsize=<%= @size %> \
--u <%= @user %> -p <%= @password %>
+-u <%= @user %> -p '<%= @password %>'
 # Init auto-failover settings for the cluster
 /opt/couchbase/bin/couchbase-cli setting-autofailover -c localhost:8091 \
 --user=<%= @user %> --password='<%= @password %>' \


### PR DESCRIPTION
This allows passwords with spaces