### PR TITLE
bug fix : when node-init fails at the first run, then the cluster is stuck : no more cluster-init and cluster-setup

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -73,6 +73,7 @@ class couchbase::config (
     logoutput => true,
     tries     => 5,
     try_sleep => 10,
+    notify    => Exec ['couchbase-init'],
   }
 
 
@@ -106,6 +107,7 @@ class couchbase::config (
     tries       => 5,
     try_sleep   => 10,
     refreshonly => true,
+    notify      => Exec['couchbase-cluster-setup'],
   }
 
   # Initialize the cluster-building script


### PR DESCRIPTION
Hello,

Originally couchbase-init and couchbase-cluster-setup are executed only when their scripts are created at the first and have dependency on couchbase-node-init.
If couchbase-node-init fails at the first run (it can happen for any reason, for instance couchbase-server takes time to be up), couchbase-init and couchbase-cluster-setup are never executed again because theirs scripts are generated only at the first run.

The fix consist in adding notifications :
couchbase-node-init ~> couchbase-init ~> couchbase-cluster-setup
