### PR TITLE
Remove extra space between Exec and '['

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -73,7 +73,7 @@ class couchbase::config (
     logoutput => true,
     tries     => 5,
     try_sleep => 10,
-    notify    => Exec ['couchbase-init'],
+    notify    => Exec['couchbase-init'],
   }
 
 


### PR DESCRIPTION
Extra space was causing a compilation error