### PR TITLE
Fix duplicate declaration of openssl package

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -80,7 +80,7 @@ class couchbase::install (
     }
   }
 
-  if ! defined(Package["${::couchbase::params::openssl_package}"]) {
+  if !defined(Package[join($::couchbase::params::openssl_package,",")]) {
     ensure_packages($::couchbase::params::openssl_package)
   }
 


### PR DESCRIPTION
I started moving our puppetmaster to puppet server 4. During testing I came into the problem that openssl package was declared twice. I have openssl installed with my base install and after that I install couchbase.

After some investigation I noticed it was because it just skipped over the if structure and went directly to the `ensure_packages` definition. I fixed this by using the stdlib module and splitting out the array.