### PR TITLE
Fix idempotency for Couchbase 4.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and automatically maintain the cluster.
 Usage
 -----
 
-Install a couchbase server with a standard user/password::
+Install a couchbase server with a standard user/password and create the [password-less](https://developer.couchbase.com/documentation/server/current/security/security-bucket-protection.html) `default` bucket:
 
     class { 'couchbase':
         size     => 1024,
@@ -16,7 +16,7 @@ Install a couchbase server with a standard user/password::
         version  => latest,
     }
 
-Create a couchbase bucket (Note the user/password)::
+Create additional buckets (Note the user/password):
 
     couchbase::bucket { 'memcached':
         port     => 11211,
@@ -27,7 +27,7 @@ Create a couchbase bucket (Note the user/password)::
         replica  => 1
     }
 
-Install the SDK for your language (currently supported ruby and python)::
+Install the SDK for your language (currently supported ruby and python):
 
     couchbase::client { 'ruby': }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -36,9 +36,13 @@ class couchbase::install (
   $pkgsource = "${download_url_base}/${version}/${pkgname}"
 
   $pkg_package = $edition ? {
-        'enterprise' => 'couchbase-server-enterprise',
-        default      => 'couchbase-server-community',
-    }
+    'enterprise' => "${version} ${method} ${::couchbase::params::installer}" ? {
+      '4.6.2 curl rpm' => 'couchbase-server',
+      default => 'couchbase-server-enterprise',
+    },
+
+    default      => 'couchbase-server-community',
+  }
 
   case $method {
     'curl': {
@@ -47,6 +51,7 @@ class couchbase::install (
         creates => "/opt/${pkgname}",
         path    => ['/usr/bin','/usr/sbin','/bin','/sbin'],
       }
+
       package {$pkg_package:
         ensure   => installed,
         name     => $pkg_package,
@@ -55,6 +60,7 @@ class couchbase::install (
         source   => "/opt/${pkgname}",
       }
     }
+
     'package': {
       package {$pkg_package:
         ensure  => $::couchbase::version,
@@ -62,6 +68,7 @@ class couchbase::install (
         require => Package[$::couchbase::params::openssl_package],
       }
     }
+
     default: {
       fail ("${module_name} install_method must be 'package' or 'curl'")
     }


### PR DESCRIPTION
Name of package in `couchbase-server-enterprise-4.6.2-centos7.x86_64.rpm` is now `couchbase-server`.

Applied only to version `4.6.2` using `curl` method to minimize breaking existing implementations.