### PR TITLE
Make `curl` method idempotent to leverage fileserver

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -50,6 +50,7 @@ class couchbase::install (
         command => "curl -o /opt/${pkgname} ${pkgsource}",
         creates => "/opt/${pkgname}",
         path    => ['/usr/bin','/usr/sbin','/bin','/sbin'],
+        unless  => "test -e /opt/${pkgname}",
       }
 
       package {$pkg_package:


### PR DESCRIPTION
Test for `/opt/${pkgname}` to skip downloading from source. Useful in supporting pre-download from fileserver.

Example:
````
class profile::couchbase::enterprise {
  ...

  # Pre-download from fileserver to skip large file download
  file { "/opt/${file_basename}":
    ensure => present,
    owner => 'root',
    mode => '0400',
    source => $file_source,
    checksum => $checksum,
    checksum_value => $file_checksum,
  } ->

  class { 'couchbase':
      edition  => $edition,
      version  => $version,
      download_url_base => $download_url_base,

      size     => $size,

      user     => $user,
      password => $password,
  }
}
````