### PR TITLE
add http_proxy variable into install class

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2018-09-04 - Version 1.2.0
+
+New:
+- add http_proxy variable into "install class" to download rpm behind firewall. 
+
 2017-07-11 - Version 1.1.0
 
 Bugfixes:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Install a couchbase server with a standard user/password and create the [passwor
         user     => 'couchbase',
         password => 'password',
         version  => latest,
+        proxy_env => ['http_proxy=http://<proxyhost>:3128', https_proxy=https://<proxyhost>:3128']
     }
 
 Create additional buckets (Note the user/password):

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,8 +68,9 @@ class couchbase
   $install_method    = 'curl',
   $autofailover      = $::couchbase::params::autofailover,
   $data_dir          = $::couchbase::params::data_dir,
-  $index_dir        = undef,
+  $index_dir         = undef,
   $download_url_base = $::couchbase::params::download_url_base,
+  $proxy_env         = undef
 ) inherits ::couchbase::params {
 
   validate_numeric($size)
@@ -83,6 +84,9 @@ class couchbase
   validate_string($ensure)
   validate_bool($autofailover)
   validate_absolute_path($data_dir)
+  if ($proxy_env) {
+    validate_array($proxy_env)
+  }
   if ($index_dir) {
     validate_absolute_path($index_dir)
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,6 +26,7 @@ class couchbase::params {
   $data_dir            = '/opt/couchbase/var/lib/couchbase/data'
   $moxi_port           = '11311'
   $moxi_version        = '2.5.0'
+  $proxy_env	       = undef
 
   case $::osfamily {
     /(?i:centos|redhat|scientific)/: {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jlondon-couchbase",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Justice London",
   "summary": "Puppet Couchbase module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Dear Justice London

I have made a small modification to the code. I added environment setting inside the INSTALL-CLASS, in particular in the task to download the package. I think is a good idea in case you are behind the firewall and you have a http proxy.
Best regards  